### PR TITLE
Link change for script plugin

### DIFF
--- a/blog/_src/posts/2018-03-21-making-an-ide-plugin-for-drracket.md
+++ b/blog/_src/posts/2018-03-21-making-an-ide-plugin-for-drracket.md
@@ -218,7 +218,7 @@ This post shows you how to make plugins for the DrRacket IDE. Both language-spec
 [^reqs]: Note that to make this mixin, the tool also must require `racket/class` and `racket/gui/base`.
 
 [PluginDocs]: https://docs.racket-lang.org/tools/index.html
-[ScrPlugin]: https://docs.racket-lang.org/script-plugin/index.html
+[ScrPlugin]: https://docs.racket-lang.org/quickscript/index.html
 [vimmode]: https://github.com/takikawa/drracket-vim-tool
 [BeautifulRacket]: https://beautifulracket.com/#tutorials
 [LanguagesDotfiles]: http://blog.racket-lang.org/2017/03/languages-as-dotfiles.html


### PR DESCRIPTION
The Script Plugin is now superseded by Quickscript.
https://github.com/Metaxal/script-plugin
https://github.com/Metaxal/quickscript
